### PR TITLE
Add simple HTML whiteboard app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# llo
-loooooo
+# Whiteboard App
+
+This repository contains a simple whiteboard web app.
+Open `index.html` in a browser to draw, change colors, adjust brush size, and clear the canvas.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Whiteboard App</title>
+  <style>
+    body { margin: 0; display: flex; flex-direction: column; height: 100vh; }
+    #toolbar { background: #eee; padding: 10px; display: flex; gap: 10px; }
+    #canvas { flex: 1; border: 1px solid #ccc; cursor: crosshair; }
+  </style>
+</head>
+<body>
+  <div id="toolbar">
+    <input type="color" id="color" value="#000000" />
+    <input type="range" id="size" min="1" max="20" value="5" />
+    <button id="clear">Clear</button>
+  </div>
+  <canvas id="canvas"></canvas>
+  <script>
+    const canvas = document.getElementById('canvas');
+    const ctx = canvas.getContext('2d');
+    const toolbar = document.getElementById('toolbar');
+    const color = document.getElementById('color');
+    const size = document.getElementById('size');
+
+    function resize() {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight - toolbar.offsetHeight;
+    }
+    window.addEventListener('resize', resize);
+    resize();
+
+    let drawing = false;
+    canvas.addEventListener('mousedown', (e) => {
+      drawing = true;
+      ctx.beginPath();
+      ctx.moveTo(e.offsetX, e.offsetY);
+    });
+    canvas.addEventListener('mousemove', (e) => {
+      if (!drawing) return;
+      ctx.lineTo(e.offsetX, e.offsetY);
+      ctx.strokeStyle = color.value;
+      ctx.lineWidth = size.value;
+      ctx.lineCap = 'round';
+      ctx.lineJoin = 'round';
+      ctx.stroke();
+    });
+    canvas.addEventListener('mouseup', () => (drawing = false));
+    canvas.addEventListener('mouseleave', () => (drawing = false));
+
+    document.getElementById('clear').addEventListener('click', () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add basic canvas-based whiteboard page with color, size, and clear controls
- document how to use the whiteboard app in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e72bb12fc832d8b8ed6283274e6de